### PR TITLE
Active queue sort

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -276,6 +276,7 @@
 						<option value="50">50</option>
 						<option value="100">100</option>
 					</select><span class="records-label"> records per page</span>
+					<input type="checkbox" id="DownloadsShowActive" onclick="Downloads.showActiveChange()"><span class="records-label"> active</span>
 				</div>
 
 				<div class="pagination pull-right"><ul id="DownloadsTable_pager"></ul></div>


### PR DESCRIPTION
Easy overview of active jobs. Controlled by checking/unchecking
a textbox.  If checked will show all jobs with status not queued first.
