### PR TITLE
Added trim method to url string value

### DIFF
--- a/webui/upload.js
+++ b/webui/upload.js
@@ -301,6 +301,7 @@ var Upload = (new function($)
 		failure_message = null;
 		index = 0;
 		url = $('#AddDialog_URL').val();
+		url = url.trim();
 
 	/*
 		setTimeout(function(){


### PR DESCRIPTION
Adding a NZB URL fails if there is a space at the start of the string, this should fix it. Often when you copy and paste a link, spaces in front of the string can occur.
