### PR TITLE
Specify -std=c++11 option in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,6 +196,7 @@ nzbget_SOURCES += \
 endif
 
 AM_CPPFLAGS = \
+	-std=c++11 \
 	-I$(srcdir)/daemon/connect \
 	-I$(srcdir)/daemon/extension \
 	-I$(srcdir)/daemon/feed \


### PR DESCRIPTION
Compilation was failing due to the lack of this option. C++11 features are currently in use, requiring this compiler flag.
