### PR TITLE
Fixed compilation error with g++ 5.3

### DIFF
--- a/daemon/connect/TlsSocket.cpp
+++ b/daemon/connect/TlsSocket.cpp
@@ -319,7 +319,7 @@ bool TlsSocket::Start()
 
 	m_initialized = true;
 
-	const char* priority = !m_cipher.Empty() ? m_cipher : "NORMAL";
+	const char* priority = !m_cipher.Empty() ? m_cipher.Str() : "NORMAL";
 
 	m_retCode = gnutls_priority_set_direct((gnutls_session_t)m_session, priority, nullptr);
 	if (m_retCode != 0)


### PR DESCRIPTION
```
daemon/connect/TlsSocket.cpp: In member function ‘bool TlsSocket::Start()’:
daemon/connect/TlsSocket.cpp:322:56: error: use of deleted function ‘CString::CString(CString&)’
  const char* priority = !m_cipher.Empty() ? m_cipher : "NORMAL";
                                                        ^
In file included from daemon/connect/TlsSocket.h:30:0,
                 from daemon/connect/TlsSocket.cpp:30:
./daemon/util/NString.h:73:2: note: declared here
  CString(CString& other) = delete;
  ^
```
