### PR TITLE
Removed in-class member initializers for VolumeArray sizes

### DIFF
--- a/daemon/nntp/StatMeter.h
+++ b/daemon/nntp/StatMeter.h
@@ -55,9 +55,9 @@ public:
 	void LogDebugInfo();
 
 private:
-	VolumeArray m_bytesPerSeconds{60};
-	VolumeArray m_bytesPerMinutes{60};
-	VolumeArray m_bytesPerHours{24};
+	VolumeArray m_bytesPerSeconds = VolumeArray(60);
+	VolumeArray m_bytesPerMinutes = VolumeArray(60);
+	VolumeArray m_bytesPerHours = VolumeArray(24);
 	VolumeArray m_bytesPerDays;
 	int m_firstDay = 0;
 	int64 m_totalBytes = 0;


### PR DESCRIPTION
The code `VolumeArray m_bytesPerSeconds{60};` actually initializes a vector of size 1, with 60 as the first element. This caused out of bounds exceptions once it tried to write to higher indices than 0 at line 92 in StatMeter.cpp.

To initialize it to size 60, I have added a constructor that does the initialization.
