### PR TITLE
Fixed guards.

### DIFF
--- a/daemon/frontend/NCursesFrontend.cpp
+++ b/daemon/frontend/NCursesFrontend.cpp
@@ -338,8 +338,8 @@ int NCursesFrontend::CalcQueueSize()
 	}
 	else
 	{
-        GuardedDownloadQueue guard = DownloadQueue::Guard();
-		for (NzbInfo* nzbInfo : guard->GetQueue())
+		GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 		{
 			queueSize += nzbInfo->GetFileList()->size();
 		}
@@ -661,8 +661,8 @@ void NCursesFrontend::PrintFileQueue()
 	int pausedFiles = 0;
 	int fileNum = 0;
 
-    GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{
@@ -1016,8 +1016,8 @@ bool NCursesFrontend::EditQueue(DownloadQueue::EEditAction action, int offset)
 	else
 	{
 		int fileNum = 0;
-		GuardedDownloadQueue guard = DownloadQueue::Guard();
-		for (NzbInfo* nzbInfo : guard->GetQueue())
+		GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 		{
 			for (FileInfo* fileInfo : nzbInfo->GetFileList())
 			{

--- a/daemon/frontend/NCursesFrontend.cpp
+++ b/daemon/frontend/NCursesFrontend.cpp
@@ -338,7 +338,8 @@ int NCursesFrontend::CalcQueueSize()
 	}
 	else
 	{
-		for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+        GuardedDownloadQueue guard = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : guard->GetQueue())
 		{
 			queueSize += nzbInfo->GetFileList()->size();
 		}
@@ -660,7 +661,8 @@ void NCursesFrontend::PrintFileQueue()
 	int pausedFiles = 0;
 	int fileNum = 0;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+    GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{
@@ -1014,7 +1016,8 @@ bool NCursesFrontend::EditQueue(DownloadQueue::EEditAction action, int offset)
 	else
 	{
 		int fileNum = 0;
-		for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+		GuardedDownloadQueue guard = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : guard->GetQueue())
 		{
 			for (FileInfo* fileInfo : nzbInfo->GetFileList())
 			{

--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -859,8 +859,8 @@ bool ArticleCache::CheckFlush(bool flushEverything)
 
 	BString<1024> infoName;
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		if (m_fileInfo)
 		{

--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -859,7 +859,8 @@ bool ArticleCache::CheckFlush(bool flushEverything)
 
 	BString<1024> infoName;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		if (m_fileInfo)
 		{

--- a/daemon/postprocess/PrePostProcessor.cpp
+++ b/daemon/postprocess/PrePostProcessor.cpp
@@ -422,8 +422,8 @@ NzbInfo* PrePostProcessor::GetNextJob(DownloadQueue* downloadQueue)
  */
 void PrePostProcessor::SanitisePostQueue()
 {
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		PostInfo* postInfo = nzbInfo->GetPostInfo();
 		if (postInfo)

--- a/daemon/postprocess/PrePostProcessor.cpp
+++ b/daemon/postprocess/PrePostProcessor.cpp
@@ -422,7 +422,8 @@ NzbInfo* PrePostProcessor::GetNextJob(DownloadQueue* downloadQueue)
  */
 void PrePostProcessor::SanitisePostQueue()
 {
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		PostInfo* postInfo = nzbInfo->GetPostInfo();
 		if (postInfo)

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -776,8 +776,8 @@ void QueueCoordinator::SavePartialState()
 		return;
 	}
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -776,7 +776,8 @@ void QueueCoordinator::SavePartialState()
 		return;
 	}
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -1494,8 +1494,8 @@ void ListFilesXmlCommand::Execute()
 
 	int index = 0;
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{
@@ -1907,8 +1907,8 @@ void ListGroupsXmlCommand::Execute()
 
 	int index = 0;
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		uint32 remainingSizeLo, remainingSizeHi, remainingSizeMB;
 		uint32 pausedSizeLo, pausedSizeHi, pausedSizeMB;
@@ -2286,8 +2286,8 @@ void PostQueueXmlCommand::Execute()
 
 	int index = 0;
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		PostInfo* postInfo = nzbInfo->GetPostInfo();
 		if (!postInfo)
@@ -2552,8 +2552,8 @@ void UrlQueueXmlCommand::Execute()
 
 	int index = 0;
 
-	GuardedDownloadQueue guard = DownloadQueue::Guard();
-	for (NzbInfo* nzbInfo : guard->GetQueue())
+	GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 	{
 		if (nzbInfo->GetKind() == NzbInfo::nkUrl)
 		{

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -1494,7 +1494,8 @@ void ListFilesXmlCommand::Execute()
 
 	int index = 0;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		for (FileInfo* fileInfo : nzbInfo->GetFileList())
 		{
@@ -1906,7 +1907,8 @@ void ListGroupsXmlCommand::Execute()
 
 	int index = 0;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		uint32 remainingSizeLo, remainingSizeHi, remainingSizeMB;
 		uint32 pausedSizeLo, pausedSizeHi, pausedSizeMB;
@@ -2284,7 +2286,8 @@ void PostQueueXmlCommand::Execute()
 
 	int index = 0;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		PostInfo* postInfo = nzbInfo->GetPostInfo();
 		if (!postInfo)
@@ -2452,7 +2455,8 @@ void HistoryXmlCommand::Execute()
 
 	int index = 0;
 
-	for (HistoryInfo* historyInfo : DownloadQueue::Guard()->GetHistory())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (HistoryInfo* historyInfo : guard->GetHistory())
 	{
 		if (historyInfo->GetKind() == HistoryInfo::hkDup && !dup)
 		{
@@ -2548,7 +2552,8 @@ void UrlQueueXmlCommand::Execute()
 
 	int index = 0;
 
-	for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+	GuardedDownloadQueue guard = DownloadQueue::Guard();
+	for (NzbInfo* nzbInfo : guard->GetQueue())
 	{
 		if (nzbInfo->GetKind() == NzbInfo::nkUrl)
 		{

--- a/daemon/windows/WinConsole.cpp
+++ b/daemon/windows/WinConsole.cpp
@@ -785,7 +785,8 @@ void WinConsole::UpdateTrayIcon()
 	{
 		int postJobCount = 0;
 		int urlCount = 0;
-		for (NzbInfo* nzbInfo : DownloadQueue::Guard()->GetQueue())
+		GuardedDownloadQueue guard = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : guard->GetQueue())
 		{
 			postJobCount += nzbInfo->GetPostInfo() ? 1 : 0;
 			urlCount += nzbInfo->GetKind() == NzbInfo::nkUrl ? 1 : 0;

--- a/daemon/windows/WinConsole.cpp
+++ b/daemon/windows/WinConsole.cpp
@@ -785,8 +785,8 @@ void WinConsole::UpdateTrayIcon()
 	{
 		int postJobCount = 0;
 		int urlCount = 0;
-		GuardedDownloadQueue guard = DownloadQueue::Guard();
-		for (NzbInfo* nzbInfo : guard->GetQueue())
+		GuardedDownloadQueue downloadQueue = DownloadQueue::Guard();
+		for (NzbInfo* nzbInfo : downloadQueue->GetQueue())
 		{
 			postJobCount += nzbInfo->GetPostInfo() ? 1 : 0;
 			urlCount += nzbInfo->GetKind() == NzbInfo::nkUrl ? 1 : 0;


### PR DESCRIPTION
The way DownloadQueue::Guard was used in foreach loops, it would destroy the guard before iteration started (as the object wasn't assigned to any variable). This caused exceptions when the file list was modified during iteration, which could happen when the lock wasn't in place.

Also, I replaced the Mutex class with std::mutex, to further the rewrite to C++14.
