### PR TITLE
Prevent a crash on android > 5.x

### DIFF
--- a/daemon/util/Script.cpp
+++ b/daemon/util/Script.cpp
@@ -92,10 +92,12 @@ void EnvironmentStrings::InitFromCurrentProcess()
 		// This is to avoid the passing of env vars after program update (when NZBGet is
 		// started from a script which was started by a previous instance of NZBGet).
 		// Format: NZBXX_YYYY (XX are any two characters, YYYY are any number of any characters).
+#ifndef ANDROID // android > 5.x crash
 		if (!(!strncmp(var, "NZB", 3) && strlen(var) > 5 && var[5] == '_'))
 		{
 			Append(var);
 		}
+#endif
 	}
 }
 


### PR DESCRIPTION
This prevent a crash on android running > 5.x. This also allow using untouched nzbget sources as a git submodule for android compilation with android-studio. Full sources will be up in a few days.
