### PR TITLE
GCC 4.8 (C++11) support

### DIFF
--- a/daemon/main/Scheduler.cpp
+++ b/daemon/main/Scheduler.cpp
@@ -40,7 +40,7 @@ void Scheduler::FirstCheck()
 		Guard guard(m_taskListMutex);
 
 		std::sort(m_taskList.begin(), m_taskList.end(),
-			[](std::unique_ptr<Task>& task1, std::unique_ptr<Task>& task2)
+			[](const std::unique_ptr<Task>& task1, const std::unique_ptr<Task>& task2)
 		{
 			return (task1->m_hours < task2->m_hours) ||
 				((task1->m_hours == task2->m_hours) && (task1->m_minutes < task2->m_minutes));

--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -340,4 +340,19 @@ typedef unsigned char uchar;
 #define SCANF_SYNTAX(strindex)
 #endif
 
+// providing "std::make_unique" for GCC 4.8.x (only 4.8.x)
+#if __GNUC__ && __cplusplus < 201402L && __cpp_generic_lambdas < 201304
+namespace std {
+template<class T> struct _Unique_if { typedef unique_ptr<T> _Single_object; };
+template<class T> struct _Unique_if<T[]> { typedef unique_ptr<T[]> _Unknown_bound; };
+template<class T, class... Args> typename _Unique_if<T>::_Single_object make_unique(Args&&... args) {
+	return unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+template<class T> typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
+	typedef typename remove_extent<T>::type U;
+	return unique_ptr<T>(new U[n]());
+}
+}
+#endif
+
 #endif /* NZBGET_H */

--- a/daemon/queue/QueueEditor.cpp
+++ b/daemon/queue/QueueEditor.cpp
@@ -38,7 +38,7 @@ public:
 	GroupSorter(NzbList* nzbList, QueueEditor::ItemList* sortItemList) :
 		m_nzbList(nzbList), m_sortItemList(sortItemList) {}
 	bool Execute(const char* sort);
-	bool operator()(std::unique_ptr<NzbInfo>& refNzbInfo1, std::unique_ptr<NzbInfo>& refNzbInfo2) const;
+	bool operator()(const std::unique_ptr<NzbInfo>& refNzbInfo1, const std::unique_ptr<NzbInfo>& refNzbInfo2) const;
 
 private:
 	enum ESortCriteria
@@ -129,7 +129,7 @@ bool GroupSorter::Execute(const char* sort)
 	std::sort(m_nzbList->begin(), m_nzbList->end(), *this);
 
 	if (origSortOrder == soAuto &&
-		std::equal(tempList.begin(), tempList.end(), m_nzbList->begin(), m_nzbList->end(),
+		std::equal(tempList.begin(), tempList.end(), m_nzbList->begin(),
 		[](NzbInfo* nzbInfo1, std::unique_ptr<NzbInfo>& nzbInfo2)
 		{
 			return nzbInfo1 == nzbInfo2.get();
@@ -142,7 +142,7 @@ bool GroupSorter::Execute(const char* sort)
 	return true;
 }
 
-bool GroupSorter::operator()(std::unique_ptr<NzbInfo>& refNzbInfo1, std::unique_ptr<NzbInfo>& refNzbInfo2) const
+bool GroupSorter::operator()(const std::unique_ptr<NzbInfo>& refNzbInfo1, const std::unique_ptr<NzbInfo>& refNzbInfo2) const
 {
 	NzbInfo* nzbInfo1 = refNzbInfo1.get();
 	NzbInfo* nzbInfo2 = refNzbInfo2.get();


### PR DESCRIPTION
With respect to a [blog](http://nuxref.com/2016/08/03/nzbget-v17-centos-7/) I wrote on NZBGet v17, the only complaint I had with it was the fact everything was re-factored to use the C++14 standards to which most (Stable) Linux distributions don't support. I was bummed out when i found out i couldn't compile it anymore with CentOS 7 specifically.

I wrote a patch that made it compatible with my OS (by reverting a bunch of the code to follow C++11 standards instead) [and shared it here](http://repo.lead2gold.org/pub/patches/nzbget/nzbget-use.c++11.patch).  Although I may have started the initiative of this change, @hugbug gets credit for _greatly_ simplifying the patch I had started and sharing it with me for this commit.

This pull request provides the ability to compile NZBGet on older Linux Distributions for those (like me) who want to build it themselves and have it link to the shared libraries maintained by our OS.
