### PR TITLE
Select-all checkbox

### DIFF
--- a/webui/config.js
+++ b/webui/config.js
@@ -2040,7 +2040,7 @@ var ScriptListDialog = (new function($)
 		$ScriptTable.on('click', 'tbody div.check',
 			function(event) { $ScriptTable.fasttable('itemCheckClick', this.parentNode.parentNode, event); });
 		$ScriptTable.on('click', 'thead div.check',
-			function() { $ScriptTable.fasttable('titleCheckClick') });
+			function(e) { $ScriptTable.fasttable('titleCheckClick', e); });
 		$ScriptTable.on('mousedown', Util.disableShiftMouseDown);
 
 		$ScriptListDialog.on('hidden', function()

--- a/webui/downloads.js
+++ b/webui/downloads.js
@@ -100,7 +100,7 @@ var Downloads = (new function($)
 		$DownloadsTable.on('click', UISettings.rowSelect ? 'tbody tr' : 'tbody div.check',
 			function(event) { $DownloadsTable.fasttable('itemCheckClick', UISettings.rowSelect ? this : this.parentNode.parentNode, event); });
 		$DownloadsTable.on('click', 'thead div.check',
-			function() { $DownloadsTable.fasttable('titleCheckClick') });
+			function(e) { $DownloadsTable.fasttable('titleCheckClick', e); });
 		$DownloadsTable.on('mousedown', Util.disableShiftMouseDown);
 	}
 

--- a/webui/edit.js
+++ b/webui/edit.js
@@ -91,7 +91,7 @@ var DownloadsEditDialog = (new function($)
 		$DownloadsFileTable.on('click', UISettings.rowSelect ? 'tbody tr' : 'tbody div.check',
 			function(event) { $DownloadsFileTable.fasttable('itemCheckClick', UISettings.rowSelect ? this : this.parentNode.parentNode, event); });
 		$DownloadsFileTable.on('click', 'thead div.check',
-			function() { $DownloadsFileTable.fasttable('titleCheckClick') });
+			function(e) { $DownloadsFileTable.fasttable('titleCheckClick', e); });
 		$DownloadsFileTable.on('mousedown', Util.disableShiftMouseDown);
 
 		$DownloadsEditDialog.on('hidden', function()

--- a/webui/fasttable.js
+++ b/webui/fasttable.js
@@ -681,12 +681,12 @@
 		}
 	}
 	
-	function checkAll(data, checked, selectEverything)
+	function checkAll(data, checked, selectVisible)
 	{
 		var filteredContent = data.filteredContent;
 		var checkedItemCount =
-			selectEverything || filteredContent.length < data.pageSize ?
-			filteredContent.length : data.pageSize;
+			selectVisible && filteredContent.length > data.pageSize ?
+			data.pageSize : filteredContent.length;
 
 		for (var i = 0; i < checkedItemCount; i++)
 		{

--- a/webui/fasttable.js
+++ b/webui/fasttable.js
@@ -649,6 +649,7 @@
 		var data = $(this).data('fasttable');
 		var filteredContent = data.filteredContent;
 		var checkedRows = data.checkedRows;
+		var modifiedClick = (e.metaKey || e.ctrlKey)
 
 		var hasSelectedItems = false;
 		for (var i = 0; i < filteredContent.length; i++)
@@ -661,7 +662,7 @@
 		}
 
 		data.lastClickedRowID = null;
-		checkAll(data, !hasSelectedItems);
+		checkAll(data, !hasSelectedItems, modifiedClick);
 	}
 
 	function toggleCheck(data, id)
@@ -680,11 +681,14 @@
 		}
 	}
 	
-	function checkAll(data, checked)
+	function checkAll(data, checked, selectEverything)
 	{
 		var filteredContent = data.filteredContent;
+		var checkedItemCount =
+			selectEverything || filteredContent.length < data.pageSize ?
+			filteredContent.length : data.pageSize;
 
-		for (var i = 0; i < filteredContent.length; i++)
+		for (var i = 0; i < checkedItemCount; i++)
 		{
 			checkRow(data, filteredContent[i].id, checked);
 		}

--- a/webui/fasttable.js
+++ b/webui/fasttable.js
@@ -644,7 +644,7 @@
 		refresh(data);
 	}
 
-	function titleCheckClick()
+	function titleCheckClick(e)
 	{
 		var data = $(this).data('fasttable');
 		var filteredContent = data.filteredContent;

--- a/webui/feed.js
+++ b/webui/feed.js
@@ -129,7 +129,7 @@ var FeedDialog = (new function($)
 		$ItemTable.on('click', UISettings.rowSelect ? 'tbody tr' : 'tbody div.check',
 			function(event) { $ItemTable.fasttable('itemCheckClick', UISettings.rowSelect ? this : this.parentNode.parentNode, event); });
 		$ItemTable.on('click', 'thead div.check',
-			function() { $ItemTable.fasttable('titleCheckClick') });
+			function(e) { $ItemTable.fasttable('titleCheckClick', e); });
 		$ItemTable.on('mousedown', Util.disableShiftMouseDown);
 
 		$FeedDialog.on('hidden', function()

--- a/webui/history.js
+++ b/webui/history.js
@@ -76,7 +76,7 @@ var History = (new function($)
 		$HistoryTable.on('click', UISettings.rowSelect ? 'tbody tr' : 'tbody div.check',
 			function(event) { $HistoryTable.fasttable('itemCheckClick', UISettings.rowSelect ? this : this.parentNode.parentNode, event); });
 		$HistoryTable.on('click', 'thead div.check',
-			function() { $HistoryTable.fasttable('titleCheckClick') });
+			function(e) { $HistoryTable.fasttable('titleCheckClick', e); });
 		$HistoryTable.on('mousedown', Util.disableShiftMouseDown);
 	}
 

--- a/webui/index.js
+++ b/webui/index.js
@@ -240,6 +240,7 @@ var Frontend = (new function($)
 		setupSearch();
 		
 		$('li > a:has(table)').addClass('has-table');
+		$('table.table-cancheck th .check').attr({ title: 'Hold Ctrl or Windows/Command key to apply action to ALL items' });
 
 		$(document).on("keypress", "form", function(event)
 		{

--- a/webui/index.js
+++ b/webui/index.js
@@ -240,7 +240,7 @@ var Frontend = (new function($)
 		setupSearch();
 		
 		$('li > a:has(table)').addClass('has-table');
-		$('table.table-cancheck th .check').attr({ title: 'Hold Ctrl or Windows/Command key to apply action to ALL items' });
+		$('table.table-cancheck th .check').attr({ title: 'Hold Ctrl or Windows/Command key to apply action to only visible items' });
 
 		$(document).on("keypress", "form", function(event)
 		{

--- a/webui/status.js
+++ b/webui/status.js
@@ -1428,7 +1428,7 @@ var LimitDialog = (new function($)
 		$ServerTable.on('click', 'tbody div.check',
 			function(event) { $ServerTable.fasttable('itemCheckClick', this.parentNode.parentNode, event); });
 		$ServerTable.on('click', 'thead div.check',
-			function() { $ServerTable.fasttable('titleCheckClick') });
+			function(e) { $ServerTable.fasttable('titleCheckClick', e); });
 		$ServerTable.on('mousedown', Util.disableShiftMouseDown);
 
 		if (UISettings.setFocus)


### PR DESCRIPTION
Default functionality is now selecting only visible. If clicked with a modifier, Control or Windows/Command, it uses it's original functionality.

Addresses #282 
