### PR TITLE
#24: Add option for file association

### DIFF
--- a/windows/setup/nzbget-setup.nsi
+++ b/windows/setup/nzbget-setup.nsi
@@ -253,8 +253,11 @@ Delete "$DESKTOP\NZBGet.lnk"
 DeleteRegKey HKCU "Software\NZBGet"
 DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet"
 
-DeleteRegKey HKCR `NZBGet.NZBFile`
-DeleteRegValue HKCR ".nzb" ""
+ReadRegStr $R0 HKCR ".nzb" ""
+${If} $R0 == "NZBGet.NZBFile"
+	DeleteRegKey HKCR `NZBGet.NZBFile`
+	DeleteRegValue HKCR ".nzb" ""
+${EndIf}
 
 ; Refresh desktop window
 System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'


### PR DESCRIPTION
This will add a checkbox so after installation finishes there will be an option to associate .nzb files with NZBGet. It will also remove the association if NZBGet is uninstalled. This solves issue number #24.