### PR TITLE
Document unlimited download rate setting

### DIFF
--- a/nzbget.conf
+++ b/nzbget.conf
@@ -1228,7 +1228,7 @@ UpdateInterval=200
 #
 # Some scheduler commands require additional parameters:
 #  DownloadRate     - download rate limit to be set (kilobytes/sec).
-#                     Example: 1000;
+#                     Example: 1000; (0 = unlimited);
 #  Script           - list of scheduler scripts to execute. The scripts in the
 #                     list must be separated with commas or semicolons. All
 #                     scripts must be stored in directory set by option


### PR DESCRIPTION
I wasn't sure if the scheduler could set an unlimited download rate like you can in the downloadrate section on the top-left of the Web UI (here) 
![image](https://cloud.githubusercontent.com/assets/4810902/25557088/e62d124c-2cd7-11e7-941c-e199f61153c7.png)

A change like this makes things more obvious. I believe nzbget.conf governs the text in the WebUI: Scheduler section.
