### PR TITLE
made arch validation more robust

### DIFF
--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -60,10 +60,11 @@ Error()
 
 ValidArch()
 {
-    LIMARCH=`echo "$ALLARCHS" | grep -w "$1"`
-    if test "$ALLARCHS" = "$LIMARCH"; then
-        return 0
-    fi
+    for arch in $ALLARCHS; do
+        if test $arch = $1; then
+            return 0
+        fi 
+    done
     return 1
 }
 

--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -60,11 +60,11 @@ Error()
 
 ValidArch()
 {
-    LIMARCH=`echo " $ALLARCHS " | sed "s/ $1 //"`
-    if test " $ALLARCHS " = "$LIMARCH"; then
-        return 1
+    LIMARCH=`echo "$ALLARCHS" | grep -w "$1"`
+    if test "$ALLARCHS" = "$LIMARCH"; then
+        return 0
     fi
-    return 0
+    return 1
 }
 
 PrintArch()

--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -60,8 +60,8 @@ Error()
 
 ValidArch()
 {
-    for arch in $ALLARCHS; do
-        if test $arch = $1; then
+    for TARG in $ALLARCHS; do
+        if test "$TARG" = "$1"; then
             return 0
         fi 
     done


### PR DESCRIPTION
The installer fails to parse i686 as a platform on the Google Pixel x686 emulator.
This is caused by some weird behavior of the ValidArch filter on this specific platform.
This fix is less 'spacy' and allows proper platform parsing.

An example of how echo piped into sed works on this platform:

    adb shell
    # var=`echo " aa bb cc " | sed "s/ cc //"`
    # echo $var
    aa bb aa bb cc
    # var=`echo " aa bb cc " | sed "s/ aa //"`
    # echo $var
    aa bb cc