### PR TITLE
added "listgroupschanged" RPC method

### DIFF
--- a/webui/downloads.js
+++ b/webui/downloads.js
@@ -47,6 +47,8 @@ var Downloads = (new function($)
 	var urls;
 	var nameColumnWidth = null;
 
+	var groupHash = '';
+
 	var statusData = {
 		'QUEUED': { Text: 'QUEUED', PostProcess: false },
 		'FETCHING': { Text: 'FETCHING', PostProcess: false },
@@ -127,15 +129,19 @@ var Downloads = (new function($)
 			$('#DownloadsTable_Category').css('width', DownloadsUI.calcCategoryColumnWidth());
 		}
 
-		RPC.call('listgroups', [], groups_loaded);
+		RPC.call('listgroupschanged', [this.groupHash], groups_loaded);
 	}
 
 	function groups_loaded(_groups)
 	{
 		if (!Refresher.isPaused())
 		{
-			groups = _groups;
-			Downloads.groups = groups;
+			if (_groups.hasOwnProperty('groups'))
+			{
+				groups = _groups['groups'];
+				Downloads.groupHash = _groups['hash'];
+				Downloads.groups = groups;
+			}
 			prepare();
 		}
 		RPC.next();


### PR DESCRIPTION
this method takes a optional string parameter and returns one of the following objects:
    `{"groups": groups, "hash": hash}`
        or
    `{"hash": hash}`
where hash is a string identifing groups and groups is identical to the data returned by a call to "listgroups".
The returned hash can be used in later calls to "listgroupschanged". groups is absent in the returned object if the hash given as a parameter is equal to the new one generated for groups because the data that would be returned is exactly the same as it was returned in a previous call.
An absent parameter in the call is treated as a string of length zero.

Using this function in the WebUI greatly reduces the data transmitted during the periodic polls for updates because the entire result of listgroups is not need to be transmitted if it is unchanged.