### PR TITLE
#421: added support for Etag an If-None-Match HTTP headers

### DIFF
--- a/daemon/remote/WebServer.cpp
+++ b/daemon/remote/WebServer.cpp
@@ -323,7 +323,7 @@ void WebProcessor::Dispatch()
 		processor.SetUserAccess((XmlRpcProcessor::EUserAccess)m_userAccess);
 		processor.SetUrl(m_url);
 		processor.Execute();
-		SendBodyResponse(processor.GetResponse(), strlen(processor.GetResponse()), processor.GetContentType(), processor.IsCachable());
+		SendBodyResponse(processor.GetResponse(), strlen(processor.GetResponse()), processor.GetContentType(), processor.IsSafeMethod());
 		return;
 	}
 
@@ -468,7 +468,7 @@ void WebProcessor::SendBodyResponse(const char* body, int bodyLen, const char* c
 	{
 		BString<1024> newETag;
 
-#ifdef DISABLE_PARCHECK
+#ifndef DISABLE_PARCHECK
 		Par2::MD5Hash hash;
 		Par2::MD5Context md5;
 		md5.Update(body, bodyLen);

--- a/daemon/remote/WebServer.cpp
+++ b/daemon/remote/WebServer.cpp
@@ -31,6 +31,8 @@
 #include "md5.h"
 #endif
 
+static const char* ERR_HTTP_OK = "200 OK";
+static const char* ERR_HTTP_NOT_MODIFIED = "304 Not Modified";
 static const char* ERR_HTTP_BAD_REQUEST = "400 Bad Request";
 static const char* ERR_HTTP_NOT_FOUND = "404 Not Found";
 static const char* ERR_HTTP_SERVICE_UNAVAILABLE = "503 Service Unavailable";
@@ -517,7 +519,7 @@ void WebProcessor::SendBodyResponse(const char* body, int bodyLen, const char* c
 	}
 
 	BString<1024> responseHeader(RESPONSE_HEADER,
-		unchanged ? (m_httpMethod == hmGet ? "304 Not Modified" : "412 Precondition Failed") : "200 OK",
+		unchanged ? ERR_HTTP_NOT_MODIFIED : ERR_HTTP_OK,
 		m_origin.Str(),
 		g_Options->GetFormAuth() ? "form" : "http",
 		m_authorized ? m_serverAuthToken[m_userAccess] : "",

--- a/daemon/remote/WebServer.h
+++ b/daemon/remote/WebServer.h
@@ -62,7 +62,7 @@ private:
 	char m_authToken[48+1];
 	static char m_serverAuthToken[3][48+1];
 	CString m_forwardedFor;
-	CString m_oldetag;
+	CString m_oldETag;
 
 	void Dispatch();
 	void SendAuthResponse();

--- a/daemon/remote/WebServer.h
+++ b/daemon/remote/WebServer.h
@@ -62,6 +62,7 @@ private:
 	char m_authToken[48+1];
 	static char m_serverAuthToken[3][48+1];
 	CString m_forwardedFor;
+	CString m_oldetag;
 
 	void Dispatch();
 	void SendAuthResponse();
@@ -69,7 +70,7 @@ private:
 	void SendErrorResponse(const char* errCode, bool printWarning);
 	void SendSingleFileResponse();
 	void SendMultiFileResponse();
-	void SendBodyResponse(const char* body, int bodyLen, const char* contentType);
+	void SendBodyResponse(const char* body, int bodyLen, const char* contentType, bool cachable);
 	void SendRedirectResponse(const char* url);
 	const char* DetectContentType(const char* filename);
 	bool IsAuthorizedIp(const char* remoteAddr);

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -50,6 +50,7 @@ public:
 	ErrorXmlCommand(int errCode, const char* errText) :
 		m_errCode(errCode), m_errText(errText) {}
 	virtual void Execute();
+	virtual bool IsError() { return true; };
 
 private:
 	int m_errCode;
@@ -428,7 +429,7 @@ void XmlRpcProcessor::Dispatch()
 		command->PrepareParams();
 		m_safeMethod = command->IsSafeMethod();
 		bool safeToExecute = m_safeMethod || m_httpMethod == XmlRpcProcessor::hmPost || m_protocol == XmlRpcProcessor::rpJsonPRpc;
-		if (safeToExecute)
+		if (safeToExecute || command->IsError())
 		{
 			command->Execute();
 			BuildResponse(command->GetResponse(), command->GetCallbackFunc(), command->GetFault(), requestId);
@@ -559,7 +560,7 @@ void XmlRpcProcessor::BuildErrorResponse(int errCode, const char* errText)
 {
 	ErrorXmlCommand command(errCode, errText);
 	command.SetRequest(m_request);
-	command.SetProtocol(rpXmlRpc);
+	command.SetProtocol(m_protocol);
 	command.PrepareParams();
 	command.Execute();
 	BuildResponse(command.GetResponse(), "", command.GetFault(), nullptr);

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -38,6 +38,14 @@
 extern void ExitProc();
 extern void Reload();
 
+class CachableXmlCommand: public XmlCommand
+{
+#ifndef DISABLE_PARCHECK
+public:
+	virtual bool IsCachable() { return true; };
+#endif
+};
+
 class ErrorXmlCommand: public XmlCommand
 {
 public:
@@ -122,14 +130,14 @@ protected:
 	virtual GuardedMessageList GuardMessages();
 };
 
-class NzbInfoXmlCommand: public XmlCommand
+class NzbInfoXmlCommand: public CachableXmlCommand
 {
 protected:
 	void AppendNzbInfoFields(NzbInfo* nzbInfo);
 	void AppendPostInfoFields(PostInfo* postInfo, int logEntries, bool postQueue);
 };
 
-class ListFilesXmlCommand: public XmlCommand
+class ListFilesXmlCommand: public CachableXmlCommand
 {
 public:
 	virtual void Execute();
@@ -199,7 +207,7 @@ public:
 	virtual void Execute();
 };
 
-class LoadConfigXmlCommand: public XmlCommand
+class LoadConfigXmlCommand: public CachableXmlCommand
 {
 public:
 	virtual void Execute();
@@ -421,6 +429,7 @@ void XmlRpcProcessor::Dispatch()
 		command->SetUserAccess(m_userAccess);
 		command->PrepareParams();
 		command->Execute();
+		m_cachable = command->IsCachable();
 		BuildResponse(command->GetResponse(), command->GetCallbackFunc(), command->GetFault(), requestId);
 	}
 }

--- a/daemon/remote/XmlRpc.h
+++ b/daemon/remote/XmlRpc.h
@@ -59,6 +59,7 @@ public:
 	const char* GetResponse() { return m_response; }
 	const char* GetContentType() { return m_contentType; }
 	static bool IsRpcRequest(const char* url);
+	bool IsCachable() { return m_cachable; };
 
 private:
 	char* m_request = nullptr;
@@ -68,6 +69,7 @@ private:
 	EUserAccess m_userAccess;
 	CString m_url;
 	StringBuilder m_response;
+	bool m_cachable = false;
 
 	void Dispatch();
 	std::unique_ptr<XmlCommand> CreateCommand(const char* methodName);
@@ -89,6 +91,7 @@ public:
 	const char* GetResponse() { return m_response; }
 	const char* GetCallbackFunc() { return m_callbackFunc; }
 	bool GetFault() { return m_fault; }
+	virtual bool IsCachable() { return false; };
 
 protected:
 	char* m_request = nullptr;

--- a/daemon/remote/XmlRpc.h
+++ b/daemon/remote/XmlRpc.h
@@ -93,6 +93,7 @@ public:
 	const char* GetCallbackFunc() { return m_callbackFunc; }
 	bool GetFault() { return m_fault; }
 	virtual bool IsSafeMethod() { return false; };
+	virtual bool IsError() { return false; };
 
 protected:
 	char* m_request = nullptr;

--- a/daemon/remote/XmlRpc.h
+++ b/daemon/remote/XmlRpc.h
@@ -59,7 +59,7 @@ public:
 	const char* GetResponse() { return m_response; }
 	const char* GetContentType() { return m_contentType; }
 	static bool IsRpcRequest(const char* url);
-	bool IsCachable() { return m_cachable; };
+	bool IsSafeMethod() { return m_safeMethod; };
 
 private:
 	char* m_request = nullptr;
@@ -69,12 +69,13 @@ private:
 	EUserAccess m_userAccess;
 	CString m_url;
 	StringBuilder m_response;
-	bool m_cachable = false;
+	bool m_safeMethod = false;
 
 	void Dispatch();
 	std::unique_ptr<XmlCommand> CreateCommand(const char* methodName);
 	void MutliCall();
 	void BuildResponse(const char* response, const char* callbackFunc, bool fault, const char* requestId);
+	void BuildErrorResponse(int errCode, const char* errText);
 };
 
 class XmlCommand
@@ -91,7 +92,7 @@ public:
 	const char* GetResponse() { return m_response; }
 	const char* GetCallbackFunc() { return m_callbackFunc; }
 	bool GetFault() { return m_fault; }
-	virtual bool IsCachable() { return false; };
+	virtual bool IsSafeMethod() { return false; };
 
 protected:
 	char* m_request = nullptr;
@@ -110,7 +111,6 @@ protected:
 	void AppendFmtResponse(const char* format, ...);
 	void AppendCondResponse(const char* part, bool cond);
 	bool IsJson();
-	bool CheckSafeMethod();
 	bool NextParamAsInt(int* value);
 	bool NextParamAsBool(bool* value);
 	bool NextParamAsStr(char** valueBuf);

--- a/webui/downloads.js
+++ b/webui/downloads.js
@@ -123,7 +123,7 @@ var Downloads = (new function($)
 
 	this.update = function()
 	{
-		RPC.call('listgroups', [], groups_loaded);
+		RPC.call('listgroups', [], groups_loaded, null, { prefer_cached: true });
 	}
 
 	function groups_loaded(_groups, _cached)

--- a/webui/downloads.js
+++ b/webui/downloads.js
@@ -46,6 +46,7 @@ var Downloads = (new function($)
 	var groups;
 	var urls;
 	var nameColumnWidth = null;
+	var cached = false;
 
 	var statusData = {
 		'QUEUED': { Text: 'QUEUED', PostProcess: false },
@@ -122,17 +123,18 @@ var Downloads = (new function($)
 
 	this.update = function()
 	{
+		RPC.call('listgroups', [], groups_loaded);
+	}
+
+	function groups_loaded(_groups, _cached)
+	{
 		if (!groups)
 		{
 			$('#DownloadsTable_Category').css('width', DownloadsUI.calcCategoryColumnWidth());
 		}
 
-		RPC.call('listgroups', [], groups_loaded);
-	}
-
-	function groups_loaded(_groups)
-	{
-		if (!Refresher.isPaused())
+		cached = _cached;
+		if (!Refresher.isPaused() && !cached)
 		{
 			groups = _groups;
 			Downloads.groups = groups;
@@ -152,6 +154,12 @@ var Downloads = (new function($)
 
 	this.redraw = function()
 	{
+		if (cached)
+		{
+			cached = false;
+			return;
+		}
+
 		if (!Refresher.isPaused())
 		{
 			redraw_table();

--- a/webui/history.js
+++ b/webui/history.js
@@ -104,7 +104,7 @@ var History = (new function($)
 
 	this.update = function()
 	{
-		RPC.call('history', [showDup], loaded);
+		RPC.call('history', [showDup], loaded, null, { prefer_cached: true });
 	}
 
 	function loaded(_history, _cached)

--- a/webui/index.js
+++ b/webui/index.js
@@ -698,7 +698,7 @@ var Frontend = (new function($)
 						$('#LoginDialog_Username').focus();
 					}
 				},
-				0, headers);
+				{ custom_headers: headers });
 		}
 
 		$('#LoginDialog_Form').submit(function(e)
@@ -722,7 +722,7 @@ var Frontend = (new function($)
 			{
 				$('#LoginDialog').modal({backdrop: 'static'});
 				$('#LoginDialog_Username').focus();
-			}, 10000);
+			}, { timeout: 10000 } );
 	}
 }(jQuery));
 
@@ -751,6 +751,9 @@ var Refresher = (new function($)
 		RPC.connectErrorMessage = 'Cannot establish connection to NZBGet.'
 		RPC.defaultFailureCallback = rpcFailure;
 		RPC.next = loadNext;
+		RPC.safeMethods = ['version', 'status', 'listgroups', 'history', 'listfiles',
+			'log', 'loadlog', 'logscript', 'logupdate', 'config', 'loadconfig',
+			'configtemplates', 'readurl', 'servervolumes'];
 
 		$('#RefreshMenu li a').click(refreshIntervalClick);
 		$('#RefreshButton').click(refreshClick);

--- a/webui/util.js
+++ b/webui/util.js
@@ -549,8 +549,6 @@ var RPC = (new function($)
 		'readurl':         true,
 		'servervolumes':   true
 	};
-	this.etags = {};
-	this.cachedResponses = {};
 
 	this.call = function(method, params, completed_callback, failure_callback, timeout, custom_headers)
 	{

--- a/webui/util.js
+++ b/webui/util.js
@@ -566,6 +566,7 @@ var RPC = (new function($)
 			{
 					var res = 'Unknown error';
 					var result;
+					var cached = false;
 					if (xhr.status === 200 || xhr.status === 412)
 					{
 						if (xhr.status === 412 || xhr.responseText != '')
@@ -573,6 +574,7 @@ var RPC = (new function($)
 							if (xhr.status === 412)
 							{
 								result = RPC.cachedResponses[method];
+								cached = true;
 							}
 							else
 							{
@@ -597,7 +599,7 @@ var RPC = (new function($)
 								if (result.error == null)
 								{
 									res = result.result;
-									completed_callback(res);
+									completed_callback(res, cached);
 									return;
 								}
 								else

--- a/webui/util.js
+++ b/webui/util.js
@@ -585,7 +585,7 @@ var RPC = (new function($)
 									res = e;
 								}
 
-								var etag = xhr.getResponseHeader('Etag');
+								var etag = xhr.getResponseHeader('ETag');
 								if (etag)
 								{
 									RPC.etags[method] = etag;

--- a/webui/util.js
+++ b/webui/util.js
@@ -549,6 +549,7 @@ var RPC = (new function($)
 		'readurl':         true,
 		'servervolumes':   true
 	};
+	this.etags = {};
 
 	this.call = function(method, params, completed_callback, failure_callback, timeout, custom_headers)
 	{
@@ -605,6 +606,13 @@ var RPC = (new function($)
 							catch (e)
 							{
 								res = e;
+							}
+
+							var etag = xhr.getResponseHeader('Etag');
+							if (etag)
+							{
+								cached = RPC.etags.hasOwnProperty(method) && RPC.etags[method] == etag;
+								RPC.etags[method] = etag;
 							}
 
 							if (result)


### PR DESCRIPTION
The web server now support Etag generation for static files and some RPC
methods. If If-None-Match is given in the request and matches with the Etag
generated for the response than no data is sent and 304 or 412 is returned.

The JavaScript RPC calls also support the new HTTP error code by buffering
Etags and responses and will reuse the previous response if 412 is returned.