### PR TITLE
#474: Add NETDB_* defines, musl compilation workaround

### DIFF
--- a/daemon/connect/Connection.h
+++ b/daemon/connect/Connection.h
@@ -33,6 +33,16 @@
 #include "TlsSocket.h"
 #endif
 
+/*
+ * Fix missing NETDB defines when using musl libc
+ */
+#if !defined(NETDB_INTERNAL)
+#  define NETDB_INTERNAL (-1)
+#endif
+#if !defined(NETDB_SUCCESS)
+#  define NETDB_SUCCESS (0)
+#endif
+
 class Connection
 {
 public:


### PR DESCRIPTION
Fixes #474 

Added missing NETDB_* defines according to glibc source: https://github.com/bminor/glibc/blob/1ffe1ccb6ec5771765f1f6f0c439ed07bf345d67/resolv/netdb.h#L71-L75