### PR TITLE
NextParamAsInt: Stop parsing at end-of-string

### DIFF
--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -893,7 +893,7 @@ bool XmlCommand::NextParamAsInt(int* value)
 		}
 		*value = atoi(param + 1);
 		m_requestPtr = param + 1;
-		while (strchr("-+0123456789&", *m_requestPtr))
+		while (*m_requestPtr && strchr("-+0123456789&", *m_requestPtr))
 		{
 			m_requestPtr++;
 		}


### PR DESCRIPTION
As discussed on https://github.com/nzbget/nzbget/issues/567

Stop parsing at end-of-string. And to avoid a heap-buffer-overflow with AddressSanitizer.
