### PR TITLE
ArticleDownloader/Decoder: Fix off by one offset

### DIFF
--- a/daemon/nntp/Decoder.cpp
+++ b/daemon/nntp/Decoder.cpp
@@ -207,6 +207,7 @@ void Decoder::ProcessYenc(char* buffer, int len)
 		{
 			pb += 7; //=strlen(" begin=")
 			m_beginPos = (int64)atoll(pb);
+			if (!m_beginPos) m_beginPos = 1;
 		}
 		pb = strstr(buffer, " end=");
 		if (pb)
@@ -275,7 +276,7 @@ Decoder::EStatus Decoder::Check()
 	{
 		case efYenc:
 			return CheckYenc();
-			 
+
 		case efUx:
 			return CheckUx();
 


### PR DESCRIPTION
When an article has yparts and the "begin" is 0 then the articleOffset
will be negative and the first article will fail to decode.

For example with:

  =ybegin part=1 line=128 size=...
  =ypart begin=0 end=...

, then we now use the beginning position reported by the article part.