### PR TITLE
proper UTF-8 encoding of email content

### DIFF
--- a/scripts/EMail.py
+++ b/scripts/EMail.py
@@ -93,6 +93,7 @@ import datetime
 import smtplib
 
 from email.mime.text import MIMEText
+from email.header import Header
 try: # python 2
 	from urllib2 import quote
 	from xmlrpclib import ServerProxy
@@ -255,8 +256,9 @@ if (os.environ.get('NZBPO_NZBLOG') == 'Always' or \
 			text += '\n%s\t%s\t%s' % (entry['Kind'], datetime.datetime.fromtimestamp(int(entry['Time'])), entry['Text'])
 
 # Create message
-msg = MIMEText(text)
-msg['Subject'] = subject
+print('[DETAIL] Creating Email')
+msg = MIMEText(text.encode('utf-8'), 'plain', 'utf-8')
+msg['Subject'] = Header(subject, 'utf-8')
 msg['From'] = os.environ['NZBPO_FROM']
 msg['To'] = os.environ['NZBPO_TO']
 msg['Date'] = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S +0000")


### PR DESCRIPTION
Hello,

I just ran into issues with the Email.py script that postprocessing failed because of errors like this:

Wed Nov 28 2018 01:20:01	DETAIL	EMail: Script successfully started
Wed Nov 28 2018 01:20:01	INFO	EMail: Traceback (most recent call last):
Wed Nov 28 2018 01:20:01	INFO	EMail:   File "/downloads/scripts/EMail.py", line 245, in <module>
Wed Nov 28 2018 01:20:01	INFO	EMail:     msg = MIMEText(text)
Wed Nov 28 2018 01:20:01	INFO	EMail:   File "/usr/lib/python2.7/email/mime/text.py", line 30, in __init__
Wed Nov 28 2018 01:20:01	INFO	EMail:     self.set_payload(_text, _charset)
Wed Nov 28 2018 01:20:01	INFO	EMail:   File "/usr/lib/python2.7/email/message.py", line 226, in set_payload
Wed Nov 28 2018 01:20:01	INFO	EMail:     self.set_charset(charset)
Wed Nov 28 2018 01:20:01	INFO	EMail:   File "/usr/lib/python2.7/email/message.py", line 262, in set_charset
Wed Nov 28 2018 01:20:01	INFO	EMail:     self._payload = self._payload.encode(charset.output_charset)
Wed Nov 28 2018 01:20:01	INFO	EMail: UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 27060: ordinal not in range(128)

I identified german umlauts and some other non ascii characters beeing the cause of these errors. I did some research and found out to avoid errors like this it's best practice to perform a proper encoding of the email body. 

In my own environment (nzbget is running in docker on Synology NAS with DSM 6.2) where python sys.getdefaultencoding() is "ascii", everything is working fine again.

Cheers,
Jürgen