### PR TITLE
Add support for http header

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -54,6 +54,7 @@ static const char* OPTION_DOWNLOADRATE			= "DownloadRate";
 static const char* OPTION_CONTROLIP				= "ControlIp";
 static const char* OPTION_CONTROLPORT			= "ControlPort";
 static const char* OPTION_CONTROLUSERNAME		= "ControlUsername";
+static const char* OPTION_CONTROLHTTPHEADER     = "ControlHttpHeader";
 static const char* OPTION_CONTROLPASSWORD		= "ControlPassword";
 static const char* OPTION_RESTRICTEDUSERNAME	= "RestrictedUsername";
 static const char* OPTION_RESTRICTEDPASSWORD	= "RestrictedPassword";
@@ -432,6 +433,7 @@ void Options::InitDefaults()
 	SetOption(OPTION_DOWNLOADRATE, "0");
 	SetOption(OPTION_CONTROLIP, "0.0.0.0");
 	SetOption(OPTION_CONTROLUSERNAME, "nzbget");
+	SetOption(OPTION_CONTROLHTTPHEADER, "");
 	SetOption(OPTION_CONTROLPASSWORD, "tegbzn6789");
 	SetOption(OPTION_RESTRICTEDUSERNAME, "");
 	SetOption(OPTION_RESTRICTEDPASSWORD, "");
@@ -672,6 +674,7 @@ void Options::InitOptions()
 	m_extensions			= GetOption(OPTION_EXTENSIONS);
 	m_controlIp				= GetOption(OPTION_CONTROLIP);
 	m_controlUsername		= GetOption(OPTION_CONTROLUSERNAME);
+	m_controlHttpHeader     = GetOption(OPTION_CONTROLHTTPHEADER);
 	m_controlPassword		= GetOption(OPTION_CONTROLPASSWORD);
 	m_restrictedUsername	= GetOption(OPTION_RESTRICTEDUSERNAME);
 	m_restrictedPassword	= GetOption(OPTION_RESTRICTEDPASSWORD);

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -224,6 +224,8 @@ public:
 	bool GetDupeCheck() { return m_dupeCheck; }
 	const char* GetControlIp() { return m_controlIp; }
 	const char* GetControlUsername() { return m_controlUsername; }
+	const char* GetControlHttpHeader() { return m_controlHttpHeader; }
+	int GetControlHttpHeaderLen() { return m_controlHttpHeader.Length(); }
 	const char* GetControlPassword() { return m_controlPassword; }
 	const char* GetRestrictedUsername() { return m_restrictedUsername; }
 	const char* GetRestrictedPassword() { return m_restrictedPassword; }
@@ -357,6 +359,7 @@ private:
 	bool m_dupeCheck = false;
 	CString m_controlIp;
 	CString m_controlUsername;
+	CString m_controlHttpHeader;
 	CString m_controlPassword;
 	CString m_restrictedUsername;
 	CString m_restrictedPassword;

--- a/daemon/remote/WebServer.h
+++ b/daemon/remote/WebServer.h
@@ -52,6 +52,7 @@ private:
 	Connection* m_connection = nullptr;
 	CString m_request;
 	CString m_url;
+	CString m_httpHeader;
 	EHttpMethod m_httpMethod;
 	EUserAccess m_userAccess;
 	bool m_rpcRequest;

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -302,6 +302,15 @@ ControlIP=0.0.0.0
 # communication see option <SecurePort>.
 ControlPort=6789
 
+# Specify a request's http header which NZBGet server uses to receive Username.
+# The password verification is skipped when the header is equal to the <ControlUsername>.
+#
+# Set to empty value to disable this fonctionnality (standard password used).
+#
+# NOTE: This option allows to support other authentication mode supported by reverse proxies
+# (e. g. Client's certificate authentication).
+ControlHttpHeader=
+
 # User name which NZBGet server and remote client use.
 #
 # Set to empty value to disable user name check (check only password).


### PR DESCRIPTION
This feature allows nzbget to delegate authentication to a reverse proxy through a localhost's socket and an http header. 