### PR TITLE
FSF address updated - fixes lint errors

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,8 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
With respect to #647, I'm in the process of properly submitting your program upstream to be available through Fedora and EPEL Repositories.

During my [package review process](https://bugzilla.redhat.com/show_bug.cgi?id=1720949) i'm getting flagged on a very small issue that requires this tiny change on your side. 

The comment that specifically targets NZBget is this:

> - Notify upstream about the wrong FSF address:
 ```
nzbget.x86_64: E: incorrect-fsf-address /usr/share/doc/nzbget-21.0/COPYING
nzbget.x86_64: E: incorrect-fsf-address /usr/share/licenses/nzbget/COPYING
```
The issue is as small as what you see in this pull request; you currently have FSF set to:
`Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA`

This is outdated. The correct (newer) address is ([see here if your concerned](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)):
`Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA`

I'll just patch it locally for now so the review process can continue; don't worry about the other errors identified; i can handle them on my end.