### PR TITLE
Fix strncasecmp size parameter off by ones

### DIFF
--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -2238,7 +2238,7 @@ void DownloadXmlCommand::Execute()
 		}
 	}
 
-	if (!strncasecmp(nzbContent, "http://", 6) || !strncasecmp(nzbContent, "https://", 7))
+	if (!strncasecmp(nzbContent, "http://", 7) || !strncasecmp(nzbContent, "https://", 8))
 	{
 		// add url
 		std::unique_ptr<NzbInfo> nzbInfo = std::make_unique<NzbInfo>();


### PR DESCRIPTION
The "http://" string has 7 bytes without nullbyte so the size in `strncasecmp(nzbContent, "http://", 6)` is off by one.

The same goes for `"https://"` string.