### PR TITLE
Fix segfault caused by malformed nzb files without subject

### DIFF
--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -209,9 +209,9 @@ private:
 	ArticleList m_articles;
 	Groups m_groups;
 	ServerStatList m_serverStats;
-	CString m_subject;
-	CString m_filename;
-	CString m_origname;
+	CString m_subject = "";
+	CString m_filename = "";
+	CString m_origname = "";
 	int64 m_size = 0;
 	int64 m_remainingSize = 0;
 	int64 m_successSize = 0;

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -660,6 +660,10 @@ void NzbFile::Parse_StartElement(const char *name, const char **atts)
 				m_fileInfo->SetTime(atoi(attrvalue));
 			}
 		}
+		if (!strcmp("", m_fileInfo->GetSubject())) {
+			m_nzbInfo->AddMessage(Message::mkWarning, "Malformed nzb-file, <file> without attribute \"subject\"");
+			return;
+		}	
 	}
 	else if (!strcmp("segment", name))
 	{
@@ -718,7 +722,9 @@ void NzbFile::Parse_EndElement(const char *name)
 	if (!strcmp("file", name))
 	{
 		// Close the file element, add the new file to file-list
-		AddFileInfo(std::move(m_fileInfo));
+		if (strcmp("", m_fileInfo->GetSubject())){
+			AddFileInfo(std::move(m_fileInfo));
+		}
 		m_article = nullptr;
 	}
 	else if (!strcmp("group", name))


### PR DESCRIPTION
fixes #744 and probably #741 

Adding NZB files without a proper subject leads to uninitialised memory access (read & write) on non-windows systems. This may segfault or just corrupt memory.

@hugbug please consider releasing this soon. I have not examined how exploitable this actually is, but worst case this may lead to remote code execution.

Example nzb:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd">
<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
<head>
 <meta type="name">Unimportant</meta>
 <meta type="category">Unimportant</meta>
</head>
<file poster="dummy" date="1234567890">
 <groups>
  <group>alt.binaries.unimportant</group>
 </groups>
 <segments>
  <segment bytes="1" number="1">unimportant</segment>
 </segments>
</file>
</nzb>
```

I haven't programmed C/C++ in 15 years, so feel free to replace the fix with something more idiomatic if you want :-)