### PR TITLE
Add registry key so Windows will display version number in programs list

### DIFF
--- a/windows/nzbget-setup.nsi
+++ b/windows/nzbget-setup.nsi
@@ -41,6 +41,7 @@
 
 Name "NZBGet"
 OutFile "nzbget-setup.exe"
+Var displayVersion "21.1"
 
 ;Default installation folder
 InstallDir "$PROGRAMFILES64\NZBGet"
@@ -179,6 +180,7 @@ WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet" "U
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet" "InstallLocation" "$INSTDIR"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet" "Publisher" "nzbget.net"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet" "DisplayIcon" "$\"$INSTDIR\nzbget.exe$\",0"
+WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NZBGet" "DisplayVersion" "$displayVersion"
 
 ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
 IntFmt $0 "0x%08X" $0


### PR DESCRIPTION
I'm not very familiar with Nullsoft / NSIS so I'm not sure if there's a more elegant way to do this, or have it automatically pull the version number from somewhere more central. But this should make it create a "DisplayVersion" string in the registry alongside the others, so Windows will actually show the version number in the Add/Remove Programs list.

This makes the program compatible with package managers/updates like [WinGet](https://devblogs.microsoft.com/commandline/windows-package-manager-1-0/), the new official Windows Package Manager.