### PR TITLE
Add native support for Apple Silicon Macs

### DIFF
--- a/osx/NZBGet.xcodeproj/project.pbxproj
+++ b/osx/NZBGet.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -324,7 +325,6 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = NZBGet;
 				SDKROOT = macosx;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -332,6 +332,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -347,7 +348,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = NZBGet;
 				SDKROOT = macosx;
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Building the daemon

You don't need to make any changes to compile the daemon for Apple Silicon. If your `openssl` is installed using Homebrew, you might need to [export some variables](https://stackoverflow.com/a/40193777) before running `./configure` and `make`.

### Universal

Build or obtain both an x86_64 (Intel) and an arm64 (Apple Silicon) variant of the `nzbget` daemon. Use `lipo` to [combine both binaries](https://stackoverflow.com/a/67946120) into a FAT binary.

![xbuild](https://user-images.githubusercontent.com/159021/135733652-6a6f1c40-2dee-4e06-96c3-529779912295.png)

---

## Building the tools

Thankfully, both `7za` and `unrar` are ready to build for Apple Silicon as well.

You could grab `7za` from Homebrew by installing the [cask](https://formulae.brew.sh/formula/p7zip) and extracting the binary:

![carbon](https://user-images.githubusercontent.com/159021/135733753-5825207a-5266-4cac-b8d4-813fd0db11d8.png)

You'll probably have to build `unrar` yourself.

### Universal

Perform the same steps found above in the daemon's Universal section.

---

## Building the wrapper

This is a little tricky. I believe the maintainers use a wrapper build script that's not in this repo. They'll have to make sure that the daemon and tools binaries they include are universal binaries (as shown above).

If you want to build it yourself:
- Make a `tools` folder under `osx/Resources`.
- In `tools`, paste in the Apple Silicon / universal binary of `7za`.
- In `tools`, paste in `cacert.pem`. (Can be found in an existing release of NZBGet.app)
- In `tools`, paste in the Apple Silicon / universal binary of `unrar`.
- Make a `daemon` folder under `osx/Resources`.
- Make a `usr` folder under `osx/Resources/daemon`.
- Make a `local` folder under `osx/Resources/daemon/usr`.
- Make a `bin` folder under `osx/Resources/daemon/usr/local`.
- In `bin`, create a symbolic link called `7za` to `../../../../tools/7za`.
- In `bin`, create a symbolic link called `7zr` to `../../../../tools/7za`.
- In `bin`, create a symbolic link called `cacert.pem` to `../../../../tools/cacert.pem`.
- In `bin`, create a symbolic link called `unrar` to `../../../../tools/unrar`.
- In `bin `, paste in the Apple Silicon / universal binary of the `nzbget` daemon.
- Make a `share` folder under `osx/Resources/daemon/usr/local`.
- Make a `nzbget` folder under `osx/Resources/daemon/usr/local/share`.
- In `share`, paste in `scripts`. (Can be found in the root of the repo)
- In `share`, paste in `webui`. (Can be found in the root of the repo)
- In `share`, paste in `nzbget.conf` or your own. (Can be found in the root of the repo)
- Open `NZBGet.xcodeproj` in `osx/` with Xcode.
- In Xcode, create a [Release build](https://stackoverflow.com/a/18038359).
- In Xcode, use the `Product` ➔ `Show Build Folder in Finder` menubar command.
- In Finder, locate the `NZBGet.app` you just built and place it in your `Applications` folder.
- In Terminal, run this command to code-sign the wrapper: `sudo codesign --force --deep --sign - /Applications/NZBGet.app`

### Universal wrapper binary built with Xcode:

![lipo](https://user-images.githubusercontent.com/159021/135733041-6ded3837-6837-4608-bac0-1409ba554b9f.png)

### Native daemon and wrapper app running on an M1 Mac:

<img width="852" alt="Screen Shot 2021-10-02 at 5 16 44 PM" src="https://user-images.githubusercontent.com/159021/135733104-cb2bd228-3aa2-44b0-8855-5f14cd9ee070.png">

### Note from Apple's [Building a Universal macOS Binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) article:

![Screen Shot 2021-10-02 at 17 14 35](https://user-images.githubusercontent.com/159021/135733078-b5620a21-807d-4634-a154-804272526fc6.png)

