### PR TITLE
Download time with empty minutes and seconds

### DIFF
--- a/scripts/EMail.py
+++ b/scripts/EMail.py
@@ -207,9 +207,9 @@ if os.environ.get('NZBPO_STATISTICS') == 'yes' and not test_mode:
 		text += '\nAverage download speed: %.2f' % (avespeed) + unit
 
 	def format_time_sec(sec):
-		Hour = sec/3600
-		Min = (sec - (sec/3600)*3600)/60
-		Sec = (sec - (sec/3600)*3600)%60
+		Hour = sec / 3600
+		Min = (sec % 3600) / 60
+		Sec = (sec % 60)
 		return '%d:%02d:%02d' % (Hour,Min,Sec)
 
 	# add times


### PR DESCRIPTION

Calculation of 
Total time
Download time
Verification time
Repair time
Unpack time
was broken for python3. Everything except hours

```
def format_time_sec_orig(sec):
    Hour = sec / 3600
    Min = (sec - (sec / 3600) * 3600) / 60
    Sec = (sec - (sec / 3600) * 3600) % 60
    return '%d:%02d:%02d' % (Hour, Min, Sec)
```

```
def format_time_sec_new(sec):
    Hour = sec / 3600
    Min = (sec % 3600) / 60
    Sec = (sec % 60)
    return '%d:%02d:%02d' % (Hour, Min, Sec)
```

```
print("Orig: " + format_time_sec_orig(int(7199)))
print("New: " + format_time_sec_new(int(7199)))
```


Output:

```
Orig: 1:00:00
New: 1:59:59
```

Before
![screenshot 147](https://user-images.githubusercontent.com/10761614/151074216-d416983d-45d2-489d-b351-f073b80029a7.jpg)

After
![screenshot 148](https://user-images.githubusercontent.com/10761614/151074238-9af4180b-79ff-4a5f-91f3-bd0f83220786.jpg)

